### PR TITLE
Concat with toggle and values

### DIFF
--- a/Sources/AsyncStore/Effect.swift
+++ b/Sources/AsyncStore/Effect.swift
@@ -74,6 +74,22 @@ public extension AsyncStore.Effect {
     static func concatenate(_ effects: Self ...) -> Self {
         .concatenate(effects: effects)
     }
+    
+    static func concatenate(_ toggleKeyPath: WritableKeyPath<State, Bool>, _ effects: Self ...) -> Self {
+        var effects = effects
+        effects.insert(.set(toggleKeyPath, to: true), at: 0)
+        effects.append(.set(toggleKeyPath, to: false))
+        
+        return .concatenate(effects: effects)
+    }
+    
+    static func concatenate<Value>(_ statusKeyPath: WritableKeyPath<State, Value>, _ values: (Value, Value),  _ effects: Self ...) -> Self {
+        var effects = effects
+        effects.insert(.set(statusKeyPath, to: values.0), at: 0)
+        effects.append(.set(statusKeyPath, to: values.1))
+
+        return .concatenate(effects: effects)
+    }
 }
 
 // MARK: Sequences


### PR DESCRIPTION
@jack0817 this is a PR to implement that feature I mentioned the other day where you can pass in a toggle to be updated.  I was also thinking it might be interesting to pass in any state property and have a start / finished value to be updated.  


feel free to shred or reject this, just wanted to play with AsyncStore at the library level for a minute and get my bearings with it more. 